### PR TITLE
PWN-5477 Add client middleware which modifies http headers

### DIFF
--- a/client/http-client/src/lib.rs
+++ b/client/http-client/src/lib.rs
@@ -39,9 +39,11 @@ mod client;
 /// HTTP transport.
 pub mod transport;
 
+mod middleware;
 #[cfg(test)]
 mod tests;
 
 pub use client::{HttpClient, HttpClientBuilder};
 pub use hyper::http::{HeaderMap, HeaderValue};
 pub use jsonrpsee_types as types;
+pub use middleware::Middleware;

--- a/client/http-client/src/middleware.rs
+++ b/client/http-client/src/middleware.rs
@@ -1,0 +1,9 @@
+use crate::HeaderMap;
+
+/// When attached to a [`HttpClientBuilder`] (generally using [`with`]), middleware is run
+/// whenever the client issues a request, in the order it was attached.
+#[async_trait::async_trait]
+pub trait Middleware: 'static + Send + Sync {
+	/// Invoked with a request before sending it.
+	async fn handle(&self, headers: &mut HeaderMap);
+}


### PR DESCRIPTION
## Problem

`jsonrpsee` doesn't have an extension point for expand client behavior. We can't propagate correlation id between services if we can't add tracing headers to http jsonrpc request.

https://p2pvalidator.atlassian.net/browse/PWN-5477

## Solution

Add middleware trait, so we can extend client behavior

## Checklist

- [ ] code changes are covered with tests
- [ ] README.md files are up to date
- [ ] CI runs without errors
- [x] code review passed (at least one other person)
